### PR TITLE
use ALC for deps

### DIFF
--- a/DSIronPython/DSIronPython.csproj
+++ b/DSIronPython/DSIronPython.csproj
@@ -3,7 +3,7 @@
 		<Import Project="$(SolutionDir)Config\shared.props" />
 	</ImportGroup>
 	<PropertyGroup>
-		<OutputPath>$(SolutionDir)\package_output\DSIronPython\bin\</OutputPath>
+		<OutputPath>$(SolutionDir)\package_output\DSIronPython\extra\</OutputPath>
 		<ProjectGuid>{9EEF4F42-6B3B-4358-9A8A-C2701539A822}</ProjectGuid>
 		<OutputType>Library</OutputType>
 		<AppDesignerFolder>Properties</AppDesignerFolder>
@@ -29,7 +29,7 @@
 		</AssemblyAttribute>
 	</ItemGroup>
 
-	<Target Name="Move python libs to extra" AfterTargets="Build">
+	<!--<Target Name="Move python libs to extra" AfterTargets="Build">
 		<ItemGroup>
 			<MySourceFiles Include="$(OutputPath)\*lib\**;" />
 		</ItemGroup>
@@ -39,7 +39,7 @@
 
 	<Target Name="Remove Lib" AfterTargets="Move python libs to extra">
 		<RemoveDir Directories="$(OutputPath)\lib" />
-	</Target>
+	</Target>-->
 
 	<Target Name="copypkgjson" AfterTargets="Build">
 		<Copy SourceFiles="pkg.json" DestinationFolder="$(OutputPath)..\"/>

--- a/IronPythonExtension/IronPythonExtension.csproj
+++ b/IronPythonExtension/IronPythonExtension.csproj
@@ -3,7 +3,7 @@
 		<Import Project="$(SolutionDir)Config\shared.props" />
 	</ImportGroup>
   <PropertyGroup>
-	<OutputPath>$(SolutionDir)\package_output\DSIronPython\bin\</OutputPath>
+	<OutputPath>$(SolutionDir)\package_output\DSIronPython\extra\</OutputPath>
     <ProjectGuid>{182FCA4E-B6EF-451F-9EC4-7BF2C622F4F7}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -21,6 +21,6 @@
     <ItemGroup>
       <ExtensionDefinition Include="IronPythonExtension_ExtensionDefinition.xml" />
     </ItemGroup>
-    <Copy SourceFiles="@(ExtensionDefinition)" DestinationFolder="$(OutputPath)..\extra" />
+    <Copy SourceFiles="@(ExtensionDefinition)" DestinationFolder="$(OutputPath)" />
   </Target>
 </Project>

--- a/IronPythonExtension/IronPythonExtension_ExtensionDefinition.xml
+++ b/IronPythonExtension/IronPythonExtension_ExtensionDefinition.xml
@@ -1,4 +1,4 @@
 <ExtensionDefinition>
-  <AssemblyPath>..\bin\IronPythonExtension.dll</AssemblyPath>
+  <AssemblyPath>IronPythonExtension.dll</AssemblyPath>
   <TypeName>IronPythonExtension.IronPythonExtension</TypeName>
 </ExtensionDefinition>


### PR DESCRIPTION

I will likely move these change to the DSIronPython3 package instead, but adding this for feedback since the changes will look exactly the same there.

~~This requires one change on the Dynamo side that I need to check with @pinzart90~~ about.
![Screenshot 2023-12-08 at 12 57 13 PM](https://github.com/DynamoDS/DSIronPython/assets/508936/8e7756a7-2257-4914-86a8-98bae5e37177)

personally I prefer the solution in this repo because it means we don't risk making any changes to Dynamo before release, and we instead can update at any time by updating the python engine packages.


The two important parts of this PR are:
1. use an ALC to load the DSIronPython engine and its dependencies.
2. move all the package binaries into the /extra folder to avoid having the package manager blindly load everything into the default ALC - instead we use the extension to create and load our deps into our own ALC.
